### PR TITLE
docs: fix Windows install typo

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -8,8 +8,8 @@ Since the module uses react-native-progress-view, it also needs to be referenced
 - Right-click main application project > Add > Reference...
   - Select `progress-view` and  in Solution Projects
   - If running 0.62, also select `RCTPdf`
-- In app `pch.h` add `#include "winrt/progress-view.h"` and `#include "winrt/RCTPdf.h"`
-- In `App.cpp` add `PackageProviders().Append(winrt::progress-view::ReactPackageProvider());` before `InitializeComponent();`
+- In app `pch.h` add `#include "winrt/progress_view.h"` and `#include "winrt/RCTPdf.h"`
+- In `App.cpp` add `PackageProviders().Append(winrt::progress_view::ReactPackageProvider());` before `InitializeComponent();`
 - If running RNW 0.62, also add `PackageProviders().Append(winrt::RCTPdf::ReactPackageProvider());`
 
 


### PR DESCRIPTION
This fixes another Windows install typo. Opening it in your fork so that it'll be included in your PR https://github.com/wonday/react-native-pdf/pull/532 after being merged.
Please merge it.
Thank you.